### PR TITLE
Support publication for wrapped builder and custom publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 
 # Local repository
 cpp/repo
+cpp/cmake-library/repo
 cpp/dependency-on-upstream-branch/list-library
 cpp/dependency-on-upstream-branch/utilities-library
 cpp/source-dependencies/repos/list-library

--- a/cpp/cmake-library/custom-publication-plugin/.gitignore
+++ b/cpp/cmake-library/custom-publication-plugin/.gitignore
@@ -1,0 +1,4 @@
+
+/.gradle
+build
+/.build

--- a/cpp/cmake-library/custom-publication-plugin/build.gradle.kts
+++ b/cpp/cmake-library/custom-publication-plugin/build.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    groovy
+    `java-gradle-plugin`
+}
+
+group = "org.gradle.samples"
+version = "1.0"
+
+gradlePlugin {
+    (plugins) {
+        "customPublication" {
+            id = "org.gradle.samples.custom-publication"
+            implementationClass = "org.gradle.samples.plugins.CustomPublicationPlugin"
+        }
+    }
+}

--- a/cpp/cmake-library/custom-publication-plugin/gradlew
+++ b/cpp/cmake-library/custom-publication-plugin/gradlew
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec "$(dirname "$0")/../../../gradlew" "$@"

--- a/cpp/cmake-library/custom-publication-plugin/gradlew.bat
+++ b/cpp/cmake-library/custom-publication-plugin/gradlew.bat
@@ -1,0 +1,2 @@
+@echo off
+call ..\..\..\gradlew.bat %*

--- a/cpp/cmake-library/custom-publication-plugin/settings.gradle.kts
+++ b/cpp/cmake-library/custom-publication-plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "custom-publication"

--- a/cpp/cmake-library/custom-publication-plugin/src/main/groovy/org/gradle/samples/plugins/CustomPublicationPlugin.groovy
+++ b/cpp/cmake-library/custom-publication-plugin/src/main/groovy/org/gradle/samples/plugins/CustomPublicationPlugin.groovy
@@ -1,0 +1,66 @@
+package org.gradle.samples.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.internal.component.UsageContext
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.bundling.Zip
+import org.gradle.language.cpp.internal.MainLibraryVariant
+import org.gradle.language.nativeplatform.internal.PublicationAwareComponent
+
+class CustomPublicationPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.plugins.withId("maven-publish") {
+            project.components.withType(PublicationAwareComponent) {
+                MainLibraryVariant mainVariant = (MainLibraryVariant) it.mainPublication
+
+                Zip publicationPackage = project.tasks.create("createPublicationPackage", Zip) {
+                    assert mainVariant.usages.size() == 1
+                    UsageContext mainUsageContext = mainVariant.usages.iterator().next()
+
+                    dependsOn { mainUsageContext.artifacts*.buildDependencies }
+
+                    from({
+                        assert mainUsageContext.artifacts.size() == 1
+                        PublishArtifact headersArtifact = mainUsageContext.artifacts.iterator().next()
+                        project.zipTree(headersArtifact.file)
+                    }) {
+                        into 'include'
+                    }
+
+
+                    dependsOn {
+                        // TODO: Make MainLibraryVariant.getVariants() lazy container to avoid ordering issues
+                        for (SoftwareComponent variant : mainVariant.variants) {
+                            from(variant*.usages.flatten()*.artifacts*.file) {
+                                into "lib/${variant.name}"
+                            }
+                        }
+
+                        return mainVariant.variants*.usages.flatten()*.artifacts*.buildDependencies
+                    }
+
+                    // TODO - should track changes to build directory
+                    destinationDir = new File(project.getBuildDir(), "custom-publications")
+                    classifier = System.getProperty("os.name").toLowerCase().replace(" ", "-")
+                    archiveName = "custom-package.zip"
+                }
+
+                project.extensions.configure(PublishingExtension) {
+                    it.publications.create("mainCustomPublication", MavenPublication) {
+                        groupId = project.getGroup().toString()
+                        artifactId = project.getName()
+                        version = project.getVersion().toString()
+                        artifact publicationPackage
+                        publishWithOriginalFileName()
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/cpp/cmake-library/list/build.gradle
+++ b/cpp/cmake-library/list/build.gradle
@@ -3,13 +3,27 @@
 buildscript {
     dependencies {
         classpath "org.gradle.samples:build-wrapper:1.0"
+        classpath "org.gradle.samples:custom-publication:1.0"
     }
 }
 
+group = "org.gradle.cpp-samples"
+version = "1.3"
+
 // Apply the cmake-library plugin explicitly as we can't use the plugins { } block
 apply plugin: 'org.gradle.samples.cmake-library'
+apply plugin: 'maven-publish'
+apply plugin: 'org.gradle.samples.custom-publication'
 
 cmake {
     binary = "src/list/liblist.a"
     includeDirectory = layout.projectDirectory.dir("src/list/include")
+}
+
+publishing {
+    repositories {
+        maven {
+            url '../repo'
+        }
+    }
 }

--- a/cpp/cmake-library/settings.gradle
+++ b/cpp/cmake-library/settings.gradle
@@ -9,5 +9,10 @@ sourceControl {
                 url = uri("build-wrapper-plugin")
             }
         }
+        withModule("org.gradle.samples:custom-publication") {
+            from(GitVersionControlSpec) {
+                url = uri("custom-publication-plugin")
+            }
+        }
     }
 }

--- a/cpp/cmake-library/utilities/build.gradle
+++ b/cpp/cmake-library/utilities/build.gradle
@@ -1,10 +1,27 @@
+buildscript {
+    dependencies {
+        classpath "org.gradle.samples:custom-publication:1.0"
+    }
+}
+
 plugins {
     id 'cpp-library'
+    id 'maven-publish'
 }
+
+apply plugin: 'org.gradle.samples.custom-publication'
 
 library {
     linkage = [Linkage.STATIC]
     dependencies {
         api project(":list")
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            url "../repo"
+        }
     }
 }

--- a/samples-dev/build.gradle
+++ b/samples-dev/build.gradle
@@ -58,6 +58,7 @@ task cleanSamples {
             file('../cpp/library-with-tests/build-wrapper-plugin'),
             file('../cpp/cmake-library/cmake-plugin'),
             file('../cpp/cmake-library/build-wrapper-plugin'),
+            file('../cpp/cmake-library/custom-publication-plugin'),
             file('../cpp/cmake-source-dependencies/cmake-plugin'),
             file('../cpp/cmake-source-dependencies/build-wrapper-plugin'),
             file('../cpp/cmake-source-dependencies/app'),
@@ -159,6 +160,8 @@ task cppCmakeLibrary(type: SourceCopyTask) {
     cmakeProject("list", "list").fromTemplate(cppListLib)
     project("build-wrapper-plugin").buildRoot()
     project("build-wrapper-plugin").fromTemplate("build-wrapper-plugin")
+    project("custom-publication-plugin").buildRoot()
+    project("custom-publication-plugin").fromTemplate("custom-publication-plugin")
 }
 
 task cppAutotoolsLibrary(type: SourceCopyTask) {
@@ -691,9 +694,18 @@ task generateBranchSwiftUtilitiesRepo(type: GitRepoTask) {
     }
 }
 
-task generateCppCmakeLibraryPluginRepo(type: GitRepoTask) {
+task generateCppCmakeLibraryBuildWrapperPluginRepo(type: GitRepoTask) {
     dependsOn cppCmakeLibrary
     sampleDir = file("../cpp/cmake-library/build-wrapper-plugin")
+    change {
+        tag("1.0")
+        "initial version"
+    }
+}
+
+task generateCppCmakeLibraryCustomPublicationPluginRepo(type: GitRepoTask) {
+    dependsOn cppCmakeLibrary
+    sampleDir = file("../cpp/cmake-library/custom-publication-plugin")
     change {
         tag("1.0")
         "initial version"

--- a/samples-dev/src/templates/build-wrapper-plugin/src/main/groovy/org/gradle/samples/WrappedPublishableComponent.groovy
+++ b/samples-dev/src/templates/build-wrapper-plugin/src/main/groovy/org/gradle/samples/WrappedPublishableComponent.groovy
@@ -1,0 +1,7 @@
+package org.gradle.samples
+
+import org.gradle.api.component.PublishableComponent
+import org.gradle.api.internal.component.SoftwareComponentInternal
+
+interface WrappedPublishableComponent extends PublishableComponent, SoftwareComponentInternal {}
+    

--- a/samples-dev/src/templates/build-wrapper-plugin/src/main/groovy/org/gradle/samples/WrappedUsageContext.groovy
+++ b/samples-dev/src/templates/build-wrapper-plugin/src/main/groovy/org/gradle/samples/WrappedUsageContext.groovy
@@ -1,0 +1,57 @@
+package org.gradle.samples
+
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.DependencyConstraint
+import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.attributes.Usage
+import org.gradle.api.capabilities.Capability
+import org.gradle.api.internal.component.UsageContext
+
+class WrappedUsageContext implements UsageContext {
+    private final String name
+    private final Usage usage
+    private final Configuration configuration
+
+    WrappedUsageContext(String name, Usage usage, Configuration configuration) {
+        this.configuration = configuration
+        this.usage = usage
+        this.name = name
+    }
+
+    @Override
+    Usage getUsage() {
+        return usage
+    }
+
+    @Override
+    Set<? extends PublishArtifact> getArtifacts() {
+        return configuration.artifacts
+    }
+
+    @Override
+    Set<? extends ModuleDependency> getDependencies() {
+        return configuration.dependencies
+    }
+
+    @Override
+    Set<? extends DependencyConstraint> getDependencyConstraints() {
+        return configuration.dependencyConstraints
+    }
+
+    @Override
+    Set<? extends Capability> getCapabilities() {
+        return Collections.emptySet()
+    }
+
+    @Override
+    String getName() {
+        return name
+    }
+
+    @Override
+    AttributeContainer getAttributes() {
+        return configuration.attributes
+    }
+}

--- a/samples-dev/src/templates/custom-publication-plugin/.gitignore
+++ b/samples-dev/src/templates/custom-publication-plugin/.gitignore
@@ -1,0 +1,4 @@
+
+/.gradle
+build
+/.build

--- a/samples-dev/src/templates/custom-publication-plugin/build.gradle.kts
+++ b/samples-dev/src/templates/custom-publication-plugin/build.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    groovy
+    `java-gradle-plugin`
+}
+
+group = "org.gradle.samples"
+version = "1.0"
+
+gradlePlugin {
+    (plugins) {
+        "customPublication" {
+            id = "org.gradle.samples.custom-publication"
+            implementationClass = "org.gradle.samples.plugins.CustomPublicationPlugin"
+        }
+    }
+}

--- a/samples-dev/src/templates/custom-publication-plugin/gradlew
+++ b/samples-dev/src/templates/custom-publication-plugin/gradlew
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec "$(dirname "$0")/../../../gradlew" "$@"

--- a/samples-dev/src/templates/custom-publication-plugin/gradlew.bat
+++ b/samples-dev/src/templates/custom-publication-plugin/gradlew.bat
@@ -1,0 +1,2 @@
+@echo off
+call ..\..\..\gradlew.bat %*

--- a/samples-dev/src/templates/custom-publication-plugin/settings.gradle.kts
+++ b/samples-dev/src/templates/custom-publication-plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "custom-publication"

--- a/samples-dev/src/templates/custom-publication-plugin/src/main/groovy/org/gradle/samples/plugins/CustomPublicationPlugin.groovy
+++ b/samples-dev/src/templates/custom-publication-plugin/src/main/groovy/org/gradle/samples/plugins/CustomPublicationPlugin.groovy
@@ -1,0 +1,66 @@
+package org.gradle.samples.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.internal.component.UsageContext
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.bundling.Zip
+import org.gradle.language.cpp.internal.MainLibraryVariant
+import org.gradle.language.nativeplatform.internal.PublicationAwareComponent
+
+class CustomPublicationPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.plugins.withId("maven-publish") {
+            project.components.withType(PublicationAwareComponent) {
+                MainLibraryVariant mainVariant = (MainLibraryVariant) it.mainPublication
+
+                Zip publicationPackage = project.tasks.create("createPublicationPackage", Zip) {
+                    assert mainVariant.usages.size() == 1
+                    UsageContext mainUsageContext = mainVariant.usages.iterator().next()
+
+                    dependsOn { mainUsageContext.artifacts*.buildDependencies }
+
+                    from({
+                        assert mainUsageContext.artifacts.size() == 1
+                        PublishArtifact headersArtifact = mainUsageContext.artifacts.iterator().next()
+                        project.zipTree(headersArtifact.file)
+                    }) {
+                        into 'include'
+                    }
+
+
+                    dependsOn {
+                        // TODO: Make MainLibraryVariant.getVariants() lazy container to avoid ordering issues
+                        for (SoftwareComponent variant : mainVariant.variants) {
+                            from(variant*.usages.flatten()*.artifacts*.file) {
+                                into "lib/${variant.name}"
+                            }
+                        }
+
+                        return mainVariant.variants*.usages.flatten()*.artifacts*.buildDependencies
+                    }
+
+                    // TODO - should track changes to build directory
+                    destinationDir = new File(project.getBuildDir(), "custom-publications")
+                    classifier = System.getProperty("os.name").toLowerCase().replace(" ", "-")
+                    archiveName = "custom-package.zip"
+                }
+
+                project.extensions.configure(PublishingExtension) {
+                    it.publications.create("mainCustomPublication", MavenPublication) {
+                        groupId = project.getGroup().toString()
+                        artifactId = project.getName()
+                        version = project.getVersion().toString()
+                        artifact publicationPackage
+                        publishWithOriginalFileName()
+                    }
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### Context
Improve wrapped build library plugin to publish binaries to a Maven repository and demonstrate a custom publication for both Gradle C++ library plugin and wrapped build library plugins.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/native-samples/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Ensure that tests pass locally: `./gradlew check`
