### PR TITLE
Created build sample for windows resource compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,12 +23,14 @@ Package.resolved
 *.vcxproj.filters
 *.vcxproj.user
 
-# AppCode/IDEA Files
+# AppCode/IDEA/Eclipse Files
 .idea
 *.iml
 *.ipr
 *.iws
 out/
+.project
+.classpath
 
 # Mac OS Junk
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -226,6 +226,22 @@ BUILD SUCCESSFUL in 1s
 > ./app/build/install/main/debug/App
 Hello, World!
 ```
+## Windows Resource Compile
+This sample shows how Gradle is able to compile Window Resource (`rc`) files and link them into a native binary.  This sample applies the `'cpp-application'` plugin.  This sample requires you have VisualCpp 
+toolchain installed
+
+### C++
+To build and run the application: (Note we are using gradlew.bat since the sample is running from Windows cmd.exe)
+
+```
+> cd cpp\windows-resources
+> gradlew.bat assemble
+
+BUILD SUCCESSFUL in 1s
+
+> .\build\exe\main\debug\windows-resources.exe
+Hello, World!
+```
 
 ## Application with library dependencies in a composite build (composite-build)
 

--- a/cpp/windows-resources/build.gradle
+++ b/cpp/windows-resources/build.gradle
@@ -1,0 +1,49 @@
+plugins {
+    id 'cpp-application'
+}
+
+
+application {
+   //source tree for CppCompile
+    source.from project.fileTree(dir: 'src', include: '**/*.cpp')
+    privateHeaders.from project.file('src/hello/headers')
+    
+    
+    binaries.whenElementFinalized { binary ->
+        if (binary.targetPlatform.operatingSystemFamily.isWindows()) {
+            //Register WindowsResourceCompile
+            def linkerTask = binary.linkTask.get()
+            def resourceTaskName = "compileResources" + binary.name.capitalize()
+            def compileResources = project.tasks.register(resourceTaskName, WindowsResourceCompile) {
+                
+                targetPlatform = binary.targetPlatform
+                toolChain = binary.toolChain
+                includes.from project.file('src/hello/headers')
+                source.from project.fileTree(dir: 'src/hello/rc' )
+                macros.put('_MYMACRO', null)
+                compilerArgs.addAll toolChain.map { NativeToolChain toolChain ->
+                    List<String> compilerSpecificArgs = []
+                    if (toolChain instanceof VisualCpp) {
+                        compilerSpecificArgs << '/v'
+                    }
+                    return compilerSpecificArgs
+                }
+                outputDir = new File(project.buildDir, "windows-resources/${binary.name}")
+            }
+
+            FileTree resourceOutputs = compileResources.get().getOutputs().getFiles().getAsFileTree().matching(new PatternSet().include(["**/*.res","**/*.obj"]));
+            linkerTask.source(resourceOutputs)
+        }
+    }
+}
+
+tasks.withType(LinkExecutable) {
+    linkerArgs.addAll toolChain.map { NativeToolChain toolChain ->
+        List<String> linkerSpecificArgs = []
+        if (toolChain instanceof VisualCpp) {
+            linkerSpecificArgs << 'user32.lib'
+        }
+        return linkerSpecificArgs
+    }
+}
+

--- a/cpp/windows-resources/gradlew
+++ b/cpp/windows-resources/gradlew
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec "$(dirname "$0")/../../gradlew" "$@"

--- a/cpp/windows-resources/gradlew.bat
+++ b/cpp/windows-resources/gradlew.bat
@@ -1,0 +1,2 @@
+@echo off
+call ..\..\gradlew.bat %*

--- a/cpp/windows-resources/settings.gradle
+++ b/cpp/windows-resources/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'windows-resources'

--- a/cpp/windows-resources/src/hello/cpp/hello.cpp
+++ b/cpp/windows-resources/src/hello/cpp/hello.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+#include <windows.h>
+#include <string>
+#include "hello.h"
+#include "resources.h"
+
+std::string LoadStringFromResource(UINT stringID)
+{
+    HINSTANCE instance = GetModuleHandle("hello");
+    WCHAR * pBuf = NULL;
+    int len = LoadStringW(instance, stringID, reinterpret_cast<LPWSTR>(&pBuf), 0);
+    std::wstring wide = std::wstring(pBuf, len);
+    return std::string(wide.begin(), wide.end());
+}
+
+void hello() {
+    std::string hello = LoadStringFromResource(IDS_HELLO);
+    std::cout << hello << std::endl;
+}

--- a/cpp/windows-resources/src/hello/headers/hello.h
+++ b/cpp/windows-resources/src/hello/headers/hello.h
@@ -1,0 +1,7 @@
+#if defined(_WIN32) && defined(DLL_EXPORT)
+#define LIB_FUNC __declspec(dllexport)
+#else
+#define LIB_FUNC
+#endif
+
+void LIB_FUNC hello();

--- a/cpp/windows-resources/src/hello/headers/resources.h
+++ b/cpp/windows-resources/src/hello/headers/resources.h
@@ -1,0 +1,1 @@
+#define IDS_HELLO    111

--- a/cpp/windows-resources/src/hello/rc/resources.rc
+++ b/cpp/windows-resources/src/hello/rc/resources.rc
@@ -1,0 +1,6 @@
+#include "resources.h"
+
+STRINGTABLE
+{
+    IDS_HELLO,   "Hello world!"
+} 

--- a/cpp/windows-resources/src/main/cpp/main.cpp
+++ b/cpp/windows-resources/src/main/cpp/main.cpp
@@ -1,0 +1,6 @@
+#include "hello.h"
+
+int main () {
+    hello();
+    return 0;
+}


### PR DESCRIPTION
Issue [#173](https://github.com/gradle/gradle-native/issues/173) 
Windows Resource Support. A sample was needed using current model instead of deprecated software model.  The build sample makes use of the 'cpp-application' plugin and wires the WindowsResourceCompile task for execution.  It is understood the DSL may change as the plugin may directly support the WRC task in future releases.

In order for this sample to work, it depends on PR #7432 where changes were made to the WindowsResourceCompile task to support the provider api ListProperty<String>.

Signed-off-by: Kent Fletcher <kfletcher@sumglobal.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/native-samples/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Ensure that tests pass locally: `./gradlew check`
