### PR TITLE
Build sample for pre-compiled headers

### DIFF
--- a/cpp/pre-compiled-headers/build.gradle
+++ b/cpp/pre-compiled-headers/build.gradle
@@ -1,0 +1,95 @@
+import org.gradle.nativeplatform.toolchain.internal.PCHUtils
+import com.google.common.collect.Lists
+
+buildscript {
+    dependencies { classpath 'com.google.guava:guava:23.0' }
+}
+
+plugins { id 'cpp-application' }
+
+task prefixGen(type: PrefixHeaderGen) {
+    header = 'pch.h'
+    prefixHeaderFile = project.file('build/tmp/hello/cpp/prefixHeaders/prefix-headers.h')
+}
+
+def pchTask = null
+
+application {
+    source.from project.file('src/hello/cpp')
+    source.from project.file('src/main/cpp')
+    privateHeaders.from project.file('src/hello/headers')
+//    pchObjects.from pchTask.objectFileDir
+//    headerFile.from prefixGen.prefixHeaderFile
+//    includeString ='pch.h'
+
+    binaries.whenElementFinalized { binary ->
+
+        if (binary.targetPlatform.operatingSystemFamily.isWindows()) {
+
+            def pchTaskName = "preCompileHeader" + binary.name.capitalize()
+            pchTask = project.tasks.register(pchTaskName, CppPreCompiledHeaderCompile) {
+                targetPlatform = binary.targetPlatform
+                toolChain = binary.toolChain
+
+                objectFileDir = new File(project.buildDir, "pch/${binary.name}PCH")
+                macros.put('DLL_EXPORT', null)
+                includes.from project.file ('src/hello/headers')
+                includes.from project.file ('src/hello/cpp')
+                includes.from project.file ('C:/Program Files (x86)/Microsoft Visual Studio/2017/Professional/VC/Tools/MSVC/14.13.26128/include')
+                includes.from project.file ('C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/um')
+                includes.from project.file ('C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/shared')
+                includes.from project.file ('C:/Program Files (x86)/Windows Kits/10/Include/10.0.16299.0/ucrt')
+                source.from prefixGen.prefixHeaderFile
+                dependsOn prefixGen
+            }
+
+            FileTree pchOutput = pchTask.get().getOutputs().getFiles().getAsFileTree().matching(new PatternSet().include("**/*.obj"));
+            binary.linkTask.get().source(pchOutput)
+        }
+    }
+}
+
+
+/*
+ * It would be nice to declare the CppPreCompiledHeaderCompile task this way
+ * but there is no visibility to targetPlatform & toolchain
+ */
+task pchGen(type: CppPreCompiledHeaderCompile) {
+    source.from project.file('src/hello/headers')
+    includes.from prefixGen.prefixHeaderFile
+    objectFileDir = new File(project.buildDir, "pchOut")
+    dependsOn prefixGen
+}
+
+//tasks.withType(CppCompile) {
+//    pchObjects.from pchTask.objectFileDir
+//    headerFile.from prefixGen.prefixHeaderFile
+//    includeString = 'pch.h'
+//}
+
+
+tasks.withType(LinkExecutable) {
+
+    linkerArgs.addAll toolChain.map { NativeToolChain toolChain ->
+        List<String> linkerSpecificArgs = []
+        if (toolChain instanceof VisualCpp) {
+            linkerSpecificArgs << 'user32.lib'
+        }
+        return linkerSpecificArgs
+    }
+}
+
+class PrefixHeaderGen extends DefaultTask {
+
+    @OutputFile
+    final RegularFileProperty prefixHeaderFile = project.objects.fileProperty()
+
+    @Input
+    final Property<String> header = project.objects.property(String)
+
+
+    @TaskAction
+    void generatePrefixHeaderFile() {
+        PCHUtils.generatePrefixHeaderFile(Lists.newArrayList(header.get()), prefixHeaderFile.getAsFile().get());
+    }
+}

--- a/cpp/pre-compiled-headers/settings.gradle
+++ b/cpp/pre-compiled-headers/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'pre-compiled-headers'

--- a/cpp/pre-compiled-headers/src/hello/cpp/hello.cpp
+++ b/cpp/pre-compiled-headers/src/hello/cpp/hello.cpp
@@ -1,0 +1,5 @@
+#include "pch.h"
+
+void LIB_FUNC Greeter::hello () {
+    std::cout << "Hello world!" << std::endl;
+}

--- a/cpp/pre-compiled-headers/src/hello/headers/hello.h
+++ b/cpp/pre-compiled-headers/src/hello/headers/hello.h
@@ -1,0 +1,13 @@
+#ifndef HELLO_H
+#define HELLO_H
+#if defined(_WIN32) && defined(DLL_EXPORT)
+#define LIB_FUNC __declspec(dllexport)
+#else
+#define LIB_FUNC
+#endif
+
+class Greeter {
+    public:
+    void LIB_FUNC hello();
+};
+#endif

--- a/cpp/pre-compiled-headers/src/hello/headers/pch.h
+++ b/cpp/pre-compiled-headers/src/hello/headers/pch.h
@@ -1,0 +1,5 @@
+#ifndef PCH_H
+#define PCH_H
+#include <iostream>
+#include "hello.h"
+#endif

--- a/cpp/pre-compiled-headers/src/main/cpp/main.cpp
+++ b/cpp/pre-compiled-headers/src/main/cpp/main.cpp
@@ -1,0 +1,7 @@
+#include "hello.h"
+
+int main () {
+    Greeter greeter;
+    greeter.hello();
+    return 0;
+}


### PR DESCRIPTION
Issue #23 Build sample for pre-compiled header using new cpp plugin,
cpp-application

Some concerns
- the sample (build.gradle) has hard coded systemIncludes because the `CppPreCompiledHeaderCompile` task isn't wired in through the CppBasePlugin.  The plugin normally figures that stuff out, but since the task is wired through build.gradle, systemIncludes had to be hard coded.  Should the `CppPreCompiledHeaderCompile` be wired into CppBasePlugin?
- the build sample doesn't consume the generated pch file.  The previous sample in the "all" distro doesn't consume the generated pch file either, it is using the software model.  I think it is broken too.
 
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/native-samples/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Ensure that tests pass locally: `./gradlew check`
