### PR TITLE
Bootstrap use of common Gradle docs infrastructure for a native-samples site

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,47 @@
+import org.asciidoctor.gradle.AsciidoctorTask
+
 // This root project is simply a container of sample builds
 plugins {
+    `java-library`
+    `kotlin-dsl`
+    id("org.asciidoctor.convert") version "1.5.3"
     id("org.gradle.samples.wrapper")
+}
+
+repositories {
+    jcenter()
+    maven { url = uri("https://repo.gradle.org/gradle/libs-releases") }
+}
+
+dependencies {
+    testImplementation("org.gradle:sample-check:0.7.0")
+    testImplementation(gradleTestKit())
+    asciidoctor("org.gradle:docs-asciidoctor-extensions:0.6.0")
+}
+
+tasks {
+    getByName<AsciidoctorTask>("asciidoctor") {
+        inputs.dir("cpp/application")
+        sourceDir = file("cpp/application")
+        outputDir = file("docs")
+        backends("html5")
+
+        attributes(
+                mapOf("source-highlighter" to "prettify",
+                        "imagesdir" to "images",
+                        "stylesheet" to null,
+                        "linkcss" to true,
+                        "docinfodir" to ".",
+                        "docinfo1" to "",
+                        "nofooter" to true,
+                        "icons" to "font",
+                        "sectanchors" to true,
+                        "sectlinks" to true,
+                        "linkattrs" to true,
+                        "encoding" to "utf-8",
+                        "idprefix" to "",
+                        "toc" to "auto",
+                        "toclevels" to 1)
+        )
+    }
 }

--- a/cpp/application/index.adoc
+++ b/cpp/application/index.adoc
@@ -1,0 +1,19 @@
+= C++ Application
+:description: A description of the sample
+
+.Assembling and running the C++ application
+====
+[.testable-sample,dir="cpp/application"]
+=====
+[.sample-command,allow-additional-output=true]
+----
+$ ./gradlew assemble
+----
+
+[.sample-command]
+----
+$ ./build/install/main/debug/app
+Hello, World!
+----
+=====
+====

--- a/src/test/java/org/gradle/samples/EmbeddedSamplesRunnerIntegrationTest.java
+++ b/src/test/java/org/gradle/samples/EmbeddedSamplesRunnerIntegrationTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.samples;
+
+import org.gradle.samples.test.runner.GradleEmbeddedSamplesRunner;
+import org.gradle.samples.test.runner.SamplesRoot;
+import org.junit.runner.RunWith;
+
+@RunWith(GradleEmbeddedSamplesRunner.class)
+@SamplesRoot("cpp/application")
+public class EmbeddedSamplesRunnerIntegrationTest {
+}


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/native-samples/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Ensure that tests pass locally: `./gradlew check`
