### PR TITLE
Fix could not build ios-application example caused by using obsolated API

### DIFF
--- a/swift/ios-application/src/main/swift/AppDelegate.swift
+++ b/swift/ios-application/src/main/swift/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
The swift/ios-applicaiton example could not pass to build by using Swift 5.

```
> Task :compileDebugSwift
/Users/uzzu/priv/gradle-native-samples/swift/ios-application/src/main/swift/AppDelegate.swift:24:98: error: 'UIApplicationLaunchOptionsKey' has been renamed to 'UIApplication.LaunchOptionsKey'
    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
                                                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                                 UIApplication.LaunchOptionsKey
UIKit.UIApplicationLaunchOptionsKey:2:18: note: 'UIApplicationLaunchOptionsKey' was obsoleted in Swift 4.2
public typealias UIApplicationLaunchOptionsKey = UIApplication.LaunchOptionsKey
                 ^
/Users/uzzu/priv/gradle-native-samples/swift/ios-application/src/main/swift/AppDelegate.swift:24:10: warning: instance method 'application(_:didFinishLaunchingWithOptions:)' nearly matches optional requirement 'application(_:didFinishLaunchingWithOptions:)' of protocol 'UIApplicationDelegate'
    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         ^
/Users/uzzu/priv/gradle-native-samples/swift/ios-application/src/main/swift/AppDelegate.swift:24:10: note: move 'application(_:didFinishLaunchingWithOptions:)' to an extension to silence this warning
    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         ^
/Users/uzzu/priv/gradle-native-samples/swift/ios-application/src/main/swift/AppDelegate.swift:24:10: note: make 'application(_:didFinishLaunchingWithOptions:)' private to silence this warning
    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         ^
    private 
UIKit.UIApplicationDelegate:7:19: note: requirement 'application(_:didFinishLaunchingWithOptions:)' declared here
    optional func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool
                  ^
```

I fixed that by using renamed API in this PR.
I also checked the builded applicaion could run on the iPhone simulator.

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/native-samples/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Ensure that tests pass locally: `./gradlew check`
