### PR TITLE
Remove `LinuxMain.swift` workaround

### DIFF
--- a/cpp/autotools-library/build-wrapper-plugin/src/main/java/org/gradle/samples/tasks/CMake.java
+++ b/cpp/autotools-library/build-wrapper-plugin/src/main/java/org/gradle/samples/tasks/CMake.java
@@ -23,11 +23,6 @@ public class CMake extends DefaultTask {
     private final ConfigurableFileCollection includeDirs = getProject().files();
     private final ConfigurableFileCollection linkFiles = getProject().files();
 
-    public CMake() {
-        dependsOn(variantDirectory);
-        dependsOn(projectDirectory);
-    }
-
     @TaskAction
     public void generateCmakeFiles() {
         String cmakeExecutable = System.getenv().getOrDefault("CMAKE_EXECUTABLE", "cmake");
@@ -50,12 +45,12 @@ public class CMake extends DefaultTask {
 
     @InputFiles
     public FileCollection getCMakeLists() {
-        return getProject().fileTree(projectDirectory.get().getAsFile(), it -> it.include("**/CMakeLists.txt"));
+        return getProject().fileTree(projectDirectory, it -> it.include("**/CMakeLists.txt"));
     }
 
     @OutputFiles
     public FileCollection getCmakeFiles() {
-        return getProject().fileTree(variantDirectory.get().getAsFile(), it -> it.include("**/CMakeFiles/**/*").include("**/Makefile").include("**/*.cmake"));
+        return getProject().fileTree(variantDirectory, it -> it.include("**/CMakeFiles/**/*").include("**/Makefile").include("**/*.cmake"));
     }
 
     @Input

--- a/cpp/cmake-library/build-wrapper-plugin/src/main/java/org/gradle/samples/tasks/CMake.java
+++ b/cpp/cmake-library/build-wrapper-plugin/src/main/java/org/gradle/samples/tasks/CMake.java
@@ -23,11 +23,6 @@ public class CMake extends DefaultTask {
     private final ConfigurableFileCollection includeDirs = getProject().files();
     private final ConfigurableFileCollection linkFiles = getProject().files();
 
-    public CMake() {
-        dependsOn(variantDirectory);
-        dependsOn(projectDirectory);
-    }
-
     @TaskAction
     public void generateCmakeFiles() {
         String cmakeExecutable = System.getenv().getOrDefault("CMAKE_EXECUTABLE", "cmake");
@@ -50,12 +45,12 @@ public class CMake extends DefaultTask {
 
     @InputFiles
     public FileCollection getCMakeLists() {
-        return getProject().fileTree(projectDirectory.get().getAsFile(), it -> it.include("**/CMakeLists.txt"));
+        return getProject().fileTree(projectDirectory, it -> it.include("**/CMakeLists.txt"));
     }
 
     @OutputFiles
     public FileCollection getCmakeFiles() {
-        return getProject().fileTree(variantDirectory.get().getAsFile(), it -> it.include("**/CMakeFiles/**/*").include("**/Makefile").include("**/*.cmake"));
+        return getProject().fileTree(variantDirectory, it -> it.include("**/CMakeFiles/**/*").include("**/Makefile").include("**/*.cmake"));
     }
 
     @Input

--- a/cpp/library-with-tests/build-wrapper-plugin/src/main/java/org/gradle/samples/tasks/CMake.java
+++ b/cpp/library-with-tests/build-wrapper-plugin/src/main/java/org/gradle/samples/tasks/CMake.java
@@ -23,11 +23,6 @@ public class CMake extends DefaultTask {
     private final ConfigurableFileCollection includeDirs = getProject().files();
     private final ConfigurableFileCollection linkFiles = getProject().files();
 
-    public CMake() {
-        dependsOn(variantDirectory);
-        dependsOn(projectDirectory);
-    }
-
     @TaskAction
     public void generateCmakeFiles() {
         String cmakeExecutable = System.getenv().getOrDefault("CMAKE_EXECUTABLE", "cmake");
@@ -50,12 +45,12 @@ public class CMake extends DefaultTask {
 
     @InputFiles
     public FileCollection getCMakeLists() {
-        return getProject().fileTree(projectDirectory.get().getAsFile(), it -> it.include("**/CMakeLists.txt"));
+        return getProject().fileTree(projectDirectory, it -> it.include("**/CMakeLists.txt"));
     }
 
     @OutputFiles
     public FileCollection getCmakeFiles() {
-        return getProject().fileTree(variantDirectory.get().getAsFile(), it -> it.include("**/CMakeFiles/**/*").include("**/Makefile").include("**/*.cmake"));
+        return getProject().fileTree(variantDirectory, it -> it.include("**/CMakeFiles/**/*").include("**/Makefile").include("**/*.cmake"));
     }
 
     @Input

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-rc-1-bin.zip
+distributionSha256Sum=74cdff9fcf830a07bf7591731a38e64a6469f400db720a2187913e8f7af6bd33
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.6-20190613112616+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples-dev/src/templates/build-wrapper-plugin/src/main/java/org/gradle/samples/tasks/CMake.java
+++ b/samples-dev/src/templates/build-wrapper-plugin/src/main/java/org/gradle/samples/tasks/CMake.java
@@ -23,11 +23,6 @@ public class CMake extends DefaultTask {
     private final ConfigurableFileCollection includeDirs = getProject().files();
     private final ConfigurableFileCollection linkFiles = getProject().files();
 
-    public CMake() {
-        dependsOn(variantDirectory);
-        dependsOn(projectDirectory);
-    }
-
     @TaskAction
     public void generateCmakeFiles() {
         String cmakeExecutable = System.getenv().getOrDefault("CMAKE_EXECUTABLE", "cmake");
@@ -50,12 +45,12 @@ public class CMake extends DefaultTask {
 
     @InputFiles
     public FileCollection getCMakeLists() {
-        return getProject().fileTree(projectDirectory.get().getAsFile(), it -> it.include("**/CMakeLists.txt"));
+        return getProject().fileTree(projectDirectory, it -> it.include("**/CMakeLists.txt"));
     }
 
     @OutputFiles
     public FileCollection getCmakeFiles() {
-        return getProject().fileTree(variantDirectory.get().getAsFile(), it -> it.include("**/CMakeFiles/**/*").include("**/Makefile").include("**/*.cmake"));
+        return getProject().fileTree(variantDirectory, it -> it.include("**/CMakeFiles/**/*").include("**/Makefile").include("**/*.cmake"));
     }
 
     @Input

--- a/samples-dev/src/templates/swift-list-lib-build-with-release/build.gradle
+++ b/samples-dev/src/templates/swift-list-lib-build-with-release/build.gradle
@@ -16,24 +16,3 @@ apply plugin: 'org.gradle.samples.release'
 
 group = 'org.gradle.swift-samples'
 version = '1.0.0'
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/samples-dev/src/templates/swift-utilities-lib-build-with-release/build.gradle
+++ b/samples-dev/src/templates/swift-utilities-lib-build-with-release/build.gradle
@@ -22,24 +22,3 @@ library {
         api 'org.gradle.swift-samples:list:1.0.0'
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/application/build.gradle
+++ b/swift/application/build.gradle
@@ -3,24 +3,3 @@ plugins {
     id 'xcode'
     id 'xctest'
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }        
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        } 
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/composite-build/build.gradle
+++ b/swift/composite-build/build.gradle
@@ -9,24 +9,3 @@ application {
         implementation 'org.gradle.swift-samples:utilities:1.2'
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/cpp-dependencies/app/build.gradle
+++ b/swift/cpp-dependencies/app/build.gradle
@@ -9,24 +9,3 @@ application {
         implementation project(':list')
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }        
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        } 
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/dependency-on-upstream-branch/app/build.gradle
+++ b/swift/dependency-on-upstream-branch/app/build.gradle
@@ -15,24 +15,3 @@ application {
         }
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/injected-plugins/build.gradle
+++ b/swift/injected-plugins/build.gradle
@@ -11,24 +11,3 @@ application {
         implementation 'org.gradle.swift-samples:utilities:latest.integration'
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/prebuilt-binaries/build.gradle
+++ b/swift/prebuilt-binaries/build.gradle
@@ -33,24 +33,3 @@ components.withType(SwiftBinary) { binary ->
         }
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }        
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        } 
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/simple-library/build.gradle
+++ b/swift/simple-library/build.gradle
@@ -5,24 +5,3 @@ plugins {
 }
 
 group = 'org.gradle.swift-samples'
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }        
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        } 
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/source-dependencies/build.gradle
+++ b/swift/source-dependencies/build.gradle
@@ -11,24 +11,3 @@ application {
         implementation 'org.gradle.swift-samples:utilities:1.0'
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/static-library/app/build.gradle
+++ b/swift/static-library/app/build.gradle
@@ -8,24 +8,3 @@ application {
         implementation project(':utilities')
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/static-library/list/build.gradle
+++ b/swift/static-library/list/build.gradle
@@ -6,24 +6,3 @@ plugins {
 library {
     linkage = [Linkage.SHARED]
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/static-library/utilities/build.gradle
+++ b/swift/static-library/utilities/build.gradle
@@ -10,24 +10,3 @@ library {
         api project(':list')
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/swift-package-manager/build.gradle
+++ b/swift/swift-package-manager/build.gradle
@@ -14,7 +14,7 @@ subprojects { subproject ->
 
     components.withType(SwiftXCTestSuite) {
         // By convention, test source files are located in the root directory/Tests/<module>Tests
-        linuxMainWorkaround(subproject, rootProject.file("Tests/${subproject.name.capitalize()}Tests"))
+        source.from rootProject.file("Tests/${subproject.name.capitalize()}Tests")
     }
 }
 
@@ -42,25 +42,6 @@ project(':utilities') {
 
 project(':list') {
     apply plugin: 'swift-library'
-}
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }        
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        } 
-    }
 }
 
 allprojects { p ->

--- a/swift/swift-versions/build.gradle
+++ b/swift/swift-versions/build.gradle
@@ -2,25 +2,6 @@ allprojects {
     apply plugin: 'xcode'
 }
 
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }        
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        } 
-    }
-}
-
 subprojects {
     apply plugin: 'swift-application'
     apply plugin: 'xctest'
@@ -28,7 +9,4 @@ subprojects {
     application {
         module = 'App'
     }
-
-    linuxMainWorkaround(project, file('src/test/swift'))
 }
-

--- a/swift/transitive-dependencies/app/build.gradle
+++ b/swift/transitive-dependencies/app/build.gradle
@@ -8,24 +8,3 @@ application {
         implementation project(':utilities')
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/transitive-dependencies/list/build.gradle
+++ b/swift/transitive-dependencies/list/build.gradle
@@ -2,24 +2,3 @@ plugins {
     id 'swift-library'
     id 'xctest'
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))

--- a/swift/transitive-dependencies/utilities/build.gradle
+++ b/swift/transitive-dependencies/utilities/build.gradle
@@ -8,24 +8,3 @@ library {
         api project(':list')
     }
 }
-
-def linuxMainWorkaround(Project project, File testDir) {
-    project.xctest {
-        source.from project.fileTree(dir: testDir, include: '**/*.swift', exclude: 'LinuxMain.swift')
-    }
-
-    if (System.properties['os.name'].equals("Linux")) {
-        // On linux, rename LinuxMain.swift -> main.swift
-        def renameLinuxMain = project.tasks.register("renameLinuxMain", Sync) {
-            from testDir
-            into temporaryDir
-            include 'LinuxMain.swift'
-            rename { 'main.swift' }
-        }
-        project.xctest {
-            source.from renameLinuxMain
-        }
-    }
-}
-
-linuxMainWorkaround(project, file('src/test/swift'))


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/native-samples/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Ensure that tests pass locally: `./gradlew check`
